### PR TITLE
Fix for author and authorUri

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = function (options) {
 
   stream.push(new gutil.File({
     path: options.path,
-    contents: new Buffer(contents)
+    contents: new Buffer(contents, 'utf8')
   }));
 
   stream.push(null);

--- a/index.js
+++ b/index.js
@@ -57,11 +57,11 @@ module.exports = function (options) {
   if (options.tags) {
     contents += 'Tags:           ' + options.tags + '\n';
   }
-  if (options.author.name) {
-    contents += 'Author:         ' + options.author.name + '\n';
+  if (options.author) {
+    contents += 'Author:         ' + options.author + '\n';
   }
-  if (options.author.uri) {
-    contents += 'Author URI:     ' + options.author.uri + '\n';
+  if (options.authorUri) {
+    contents += 'Author URI:     ' + options.authorUri + '\n';
   }
   if (options.license) {
     contents += 'License:        ' + options.license + '\n';


### PR DESCRIPTION
In the initial `index.js` said options was set from undefined objects `options.author.name` and `options.authorUri`.